### PR TITLE
Add new contracts

### DIFF
--- a/contracts/anchors/bridged/2/WEBBAnchor2.sol
+++ b/contracts/anchors/bridged/2/WEBBAnchor2.sol
@@ -5,7 +5,6 @@
 
 pragma solidity ^0.8.0;
 
-import "../../../tokens/CompToken.sol";
 import "../../../interfaces/IMintableCompToken.sol";
 import "./LinkableAnchor2.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -31,7 +30,7 @@ contract WEBBAnchor2 is LinkableAnchor2 {
 
   function _processDeposit() internal override {
     require(msg.value == 0, "ETH value is supposed to be 0 for ERC20 instance");
-    IMintableERC20(token).transferFrom(msg.sender, address(this), denomination);
+    IMintableCompToken(token).transferFrom(msg.sender, address(this), denomination);
   }
 
   function _processWithdraw(
@@ -52,9 +51,9 @@ contract WEBBAnchor2 is LinkableAnchor2 {
       }
     } else {
       // mint tokens when not enough balance exists
-      IMintableERC20(token).mint(_recipient, denomination - _fee);
+      IMintableCompToken(token).mint(_recipient, denomination - _fee);
       if (_fee > 0) {
-        IMintableERC20(token).mint(_relayer, _fee);
+        IMintableCompToken(token).mint(_relayer, _fee);
       }
     }
 

--- a/contracts/tokens/CompGovernedTokenWrapper.sol
+++ b/contracts/tokens/CompGovernedTokenWrapper.sol
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2021 Webb Technologies
+ * SPDX-License-Identifier: GPL-3.0-or-later-only
+ */
+ 
+pragma solidity ^0.8.0;
+
+import "./CompTokenWrapper.sol";
+
+/**
+    @title Governs allowable ERC20s to deposit using a governable wrapping limit.
+    @author Webb Technologies.
+    @notice This contract is intended to be used with ERC20Handler contract.
+ */
+contract CompGovernedTokenWrapper is CompTokenWrapper {
+  address public governor;
+  address[] public tokens;
+  mapping (address => bool) valid;
+
+  uint256 public wrappingLimit;
+
+  constructor(string memory name, string memory symbol, address _governor, uint256 _limit) CompTokenWrapper(name, symbol) {
+    governor = _governor;
+    wrappingLimit = _limit;
+  }
+
+  function setGovernor(address _governor) public onlyGovernor {
+    governor = _governor;
+  }
+
+  function _isValidAddress(address tokenAddress) override internal virtual returns (bool) {
+    return valid[tokenAddress];
+  }
+
+  function _isValidAmount(uint256 amount) override internal virtual returns (bool) {
+    return amount + this.totalSupply() <= wrappingLimit;
+  }
+
+  function add(address tokenAddress) public onlyGovernor {
+    require(!valid[tokenAddress], "Token should not be valid");
+    tokens.push(tokenAddress);
+    valid[tokenAddress] = true;
+  }
+
+  function updateLimit(uint256 limit) public onlyGovernor {
+    wrappingLimit = limit;
+  }
+
+  function getTokens() external view returns (address[] memory) {
+    return tokens;
+  }
+
+  modifier onlyGovernor() {
+    require(msg.sender == governor, "Only governor can call this function");
+    _;
+  }
+}

--- a/contracts/tokens/CompTokenWrapper.sol
+++ b/contracts/tokens/CompTokenWrapper.sol
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2021 Webb Technologies
+ * SPDX-License-Identifier: GPL-3.0-or-later-only
+ */
+ 
+pragma solidity ^0.8.0;
+
+import "../interfaces/ITokenWrapper.sol";
+import "./CompToken.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+
+/**
+    @title Manages deposited ERC20s.
+    @author ChainSafe Systems.
+    @notice This contract is intended to be used with ERC20Handler contract.
+ */
+abstract contract CompTokenWrapper is CompToken, ITokenWrapper {
+    using SafeMath for uint256;
+
+    constructor(string memory name, string memory symbol)
+        CompToken(name, symbol) {}
+
+    /**
+        @notice Used to wrap tokens on behalf of a sender. Must be called by a minter role.
+        @param tokenAddress Address of ERC20 to transfer.
+        @param amount Amount of tokens to transfer.
+     */
+    function wrap(address tokenAddress, uint256 amount) override public {
+        require(_isValidAddress(tokenAddress), "Invalid token address");
+        require(_isValidAmount(amount), "Invalid token amount");
+        // transfer liquidity to the token wrapper
+        IERC20(tokenAddress).transferFrom(_msgSender(), address(this), amount);
+        // mint the wrapped token for the sender
+        _mint(_msgSender(), amount);
+    }
+
+    /**
+        @notice Used to unwrap/burn the wrapper token on behalf of a sender.
+        @param tokenAddress Address of ERC20 to unwrap into.
+        @param amount Amount of tokens to burn.
+     */
+    function unwrap(address tokenAddress, uint256 amount) override public {
+        require(_isValidAddress(tokenAddress), "Invalid token address");
+        require(_isValidAmount(amount), "Invalid token amount");
+        // burn wrapped token from sender
+        _burn(_msgSender(), amount);
+        // transfer liquidity from the token wrapper to the sender
+        IERC20(tokenAddress).transfer(_msgSender(), amount);
+    }
+
+    /**
+        @notice Used to wrap tokens on behalf of a sender
+        @param tokenAddress Address of ERC20 to transfer.
+        @param amount Amount of tokens to transfer.
+     */
+    function wrapFor(address sender, address tokenAddress, uint256 amount) override public {
+        require(hasRole(MINTER_ROLE, msg.sender), "ERC20PresetMinterPauser: must have minter role");
+        require(_isValidAddress(tokenAddress), "Invalid token address");
+        require(_isValidAmount(amount), "Invalid token amount");
+        // transfer liquidity to the token wrapper
+        IERC20(tokenAddress).transferFrom(sender, address(this), amount);
+        // mint the wrapped token for the sender
+        mint(sender, amount);
+    }
+
+    /**
+        @notice Used to unwrap/burn the wrapper token.
+        @param tokenAddress Address of ERC20 to unwrap into.
+        @param amount Amount of tokens to burn.
+     */
+    function unwrapFor(address sender, address tokenAddress, uint256 amount) override public {
+        require(hasRole(MINTER_ROLE, msg.sender), "ERC20PresetMinterPauser: must have minter role");
+        require(_isValidAddress(tokenAddress), "Invalid token address");
+        require(_isValidAmount(amount), "Invalid token amount");
+        // burn wrapped token from sender
+        _burn(sender, amount);
+        // transfer liquidity from the token wrapper to the sender
+        IERC20(tokenAddress).transfer(sender, amount);
+    }
+
+    /** @dev this function is defined in a child contract */
+    function _isValidAddress(address tokenAddress) internal virtual returns (bool);
+
+    /** @dev this function is defined in a child contract */
+    function _isValidAmount(uint256 amount) internal virtual returns (bool);
+}


### PR DESCRIPTION
The main intention here is that we can reuse the WEBB anchor for any token that we also want to have governable rights over its wrappings. This will allow us to test different anchors that both allow wraps/unwraps to and from it but also govern that whitelisted set of wrapping tokens allowed.

There is still some work to be done, likely behind the gov bravo contracts that govern the sets. For these tokens / anchors, we may want to explore dynamic thresholds for proposal governance that is based on total supply.